### PR TITLE
Update to Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
-        "illuminate/filesystem": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
+        "illuminate/support": "6.0.X",
+        "illuminate/filesystem": "6.0.X",
         "symfony/process": "v2.x|v3.x|v4.x"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "6.0.X",
-        "illuminate/filesystem": "6.0.X",
+        "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.0.X",
+        "illuminate/filesystem": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.0.X",
         "symfony/process": "v2.x|v3.x|v4.x"
     },
     "autoload": {

--- a/src/Latex.php
+++ b/src/Latex.php
@@ -7,6 +7,7 @@ use ZsgsDesign\PDFConverter\LatexPdfWasGenerated;
 use ZsgsDesign\PDFConverter\LatexPdfFailed;
 use ZsgsDesign\PDFConverter\ViewNotFoundException;
 use Symfony\Component\Process\Process;
+use Illuminate\Support\Str;
 
 class Latex
 {
@@ -230,7 +231,7 @@ class Latex
      */
     private function generate()
     {
-        $fileName = str_random(10);
+        $fileName = Str::random(10);
         $tmpfname = tempnam(sys_get_temp_dir(), $fileName);
         $tmpDir = sys_get_temp_dir();
         chmod($tmpfname, 0755);


### PR DESCRIPTION
Heads up!

I have updated Latex.php with the new helper Str::random but I don't know if this works with the requirements "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.0.X".

(I am just using this package in a new laravel 6 installation. I found that the original repo was unmantained and check that your fork works fine).